### PR TITLE
Add dark mode toggle and dive logging form

### DIFF
--- a/dive.html
+++ b/dive.html
@@ -10,6 +10,13 @@
 </head>
 <body>
     <h1>US NAVY REV 7 No-Decompression Limits Live Chart</h1>
+    <div class="top-bar">
+        <button id="logItButton">Log It</button>
+        <label class="theme-switch">
+            <input type="checkbox" id="themeToggle">
+            <span class="slider"></span>
+        </label>
+    </div>
     <div class="controls">
         <label for="depthSelect">Select Anticipated Depth:</label>
         <select id="depthSelect">
@@ -37,6 +44,26 @@
         <h3>Dive Log</h3>
         <div id="logContent"></div>
     </div>
+    <div id="logForm" class="log-form" style="display:none;">
+        <h3>Dive Log Details</h3>
+        <form id="diveForm">
+            <label>Company Name: <input type="text" id="companyName"></label><br>
+            <label>Company Address: <input type="text" id="companyAddress"></label><br>
+            <label>Location: <input type="text" id="location"></label><br>
+            <label>Date &amp; Time: <input type="text" id="diveDateTime" readonly></label><br>
+            <label>Dive Supervisor: <input type="text" id="supervisor"></label><br>
+            <label>Diver: <input type="text" id="diver"></label><br>
+            <label>Tender: <input type="text" id="tender"></label><br>
+            <div id="additionalPeople"></div>
+            <button type="button" id="addPerson">Add Person</button><br>
+            <label>Depth of Dive: <input type="text" id="depthLogged" readonly></label><br>
+            <label>Bottom Time: <input type="text" id="bottomTimeLogged" readonly></label><br>
+            <label>Sea State: <select id="seaState"><option>Calm</option><option>Moderate</option><option>Rough</option></select></label><br>
+            <label>Visibility: <select id="visibility"><option>Poor</option><option>Fair</option><option>Good</option><option>Excellent</option></select></label><br>
+            <label>Current: <select id="current"><option>None</option><option>Mild</option><option>Moderate</option><option>Strong</option></select></label><br>
+            <label>Decompression Table: <input type="text" id="decoTable" value="US Navy Rev 7" readonly></label>
+        </form>
+    </div>
 
     <!-- Load dive data before running the main script -->
     <script src="diveData.js"></script>
@@ -55,6 +82,15 @@
         const tableBody = document.getElementById('tableBody');
         const log = document.getElementById('log');
         const logContent = document.getElementById('logContent');
+        const logItButton = document.getElementById('logItButton');
+        const logForm = document.getElementById('logForm');
+        const themeToggle = document.getElementById('themeToggle');
+        const diveDateTime = document.getElementById('diveDateTime');
+        const locationInput = document.getElementById('location');
+        const depthLogged = document.getElementById('depthLogged');
+        const bottomTimeLogged = document.getElementById('bottomTimeLogged');
+        const addPersonBtn = document.getElementById('addPerson');
+        const additionalPeople = document.getElementById('additionalPeople');
 
         function populateDepthSelect() {
             noStopLimits.forEach(row => {
@@ -196,11 +232,49 @@ function getRepetitiveGroup(depth, time) {
             `;
 
             log.style.display = 'block';
+
+            depthLogged.value = `${confirmedDepth} ft`;
+            bottomTimeLogged.value = formatTime(elapsedMilliseconds);
         }
 
         window.addEventListener('DOMContentLoaded', () => {
             populateDepthSelect();
             updateTable();
+
+            if (localStorage.getItem('theme') === 'dark') {
+                document.body.classList.add('dark-mode');
+                themeToggle.checked = true;
+            }
+
+            themeToggle.addEventListener('change', () => {
+                if (themeToggle.checked) {
+                    document.body.classList.add('dark-mode');
+                    localStorage.setItem('theme', 'dark');
+                } else {
+                    document.body.classList.remove('dark-mode');
+                    localStorage.setItem('theme', 'light');
+                }
+            });
+
+            logItButton.addEventListener('click', () => {
+                logForm.style.display = logForm.style.display === 'none' ? 'block' : 'none';
+                if (logForm.style.display === 'block') {
+                    diveDateTime.value = new Date().toLocaleString();
+                    if (navigator.geolocation) {
+                        navigator.geolocation.getCurrentPosition(pos => {
+                            locationInput.value = `${pos.coords.latitude.toFixed(5)}, ${pos.coords.longitude.toFixed(5)}`;
+                        });
+                    }
+                }
+            });
+
+            addPersonBtn.addEventListener('click', () => {
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.placeholder = 'Additional Person';
+                additionalPeople.appendChild(input);
+                additionalPeople.appendChild(document.createElement('br'));
+            });
 
             depthSelect.addEventListener('change', (event) => {
                 selectedDepth = parseInt(event.target.value);

--- a/diveStyles.css
+++ b/diveStyles.css
@@ -7,6 +7,100 @@
         color: #003366;
     }
 
+    body.dark-mode {
+        background-color: #121212;
+        color: #e0e0e0;
+    }
+
+    body.dark-mode h1 {
+        background-color: #222;
+        color: #e0e0e0;
+    }
+
+    body.dark-mode .controls,
+    body.dark-mode .timer,
+    body.dark-mode table,
+    body.dark-mode .log,
+    body.dark-mode .log-form {
+        background-color: #333;
+        color: #e0e0e0;
+    }
+
+    body.dark-mode table th {
+        background-color: #555;
+        color: #e0e0e0;
+    }
+
+    body.dark-mode button {
+        background-color: #555;
+        color: #e0e0e0;
+    }
+
+    body.dark-mode button:hover {
+        background-color: #777;
+    }
+
+    .top-bar {
+        display: flex;
+        justify-content: space-between;
+        padding: 10px 20px;
+    }
+
+    .theme-switch {
+        position: relative;
+        display: inline-block;
+        width: 50px;
+        height: 24px;
+    }
+
+    .theme-switch input {
+        display: none;
+    }
+
+    .theme-switch .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #ccc;
+        transition: 0.4s;
+        border-radius: 34px;
+    }
+
+    .theme-switch .slider:before {
+        position: absolute;
+        content: "";
+        height: 18px;
+        width: 18px;
+        left: 3px;
+        bottom: 3px;
+        background-color: white;
+        transition: 0.4s;
+        border-radius: 50%;
+    }
+
+    .theme-switch input:checked + .slider {
+        background-color: #003366;
+    }
+
+    .theme-switch input:checked + .slider:before {
+        transform: translateX(26px);
+    }
+
+    .log-form label {
+        display: block;
+        margin-bottom: 6px;
+    }
+
+    .log-form input, .log-form select {
+        width: 100%;
+        margin-bottom: 10px;
+        padding: 6px;
+        box-sizing: border-box;
+    }
+
     h1 {
         text-align: center;
         font-family: "Courier New", Courier, monospace;


### PR DESCRIPTION
## Summary
- add a top bar with a "Log It" button and theme toggle
- implement dark-mode styles and switch
- create a dive log form for recording dive details
- hook up JS to populate the log form and control theme persistence

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685dcc23a51c83308de89b18af7528d4